### PR TITLE
お題一覧画面に曜日を表示するように変更

### DIFF
--- a/lib/screens/daily_theme/daily_themes_screen.dart
+++ b/lib/screens/daily_theme/daily_themes_screen.dart
@@ -1,6 +1,7 @@
 import 'package:aipictors/graphql/__generated__/daily_themes.req.gql.dart';
 import 'package:aipictors/providers/client_provider.dart';
 import 'package:aipictors/screens/loading_screen.dart';
+import 'package:aipictors/utils/to_weekday.dart';
 import 'package:aipictors/widgets/app_bar/daily_themes_app_bar.dart';
 import 'package:aipictors/widgets/builder/operation_builder.dart';
 import 'package:aipictors/widgets/container/error/data_empty_error_container.dart';
@@ -69,6 +70,7 @@ class DailyThemesScreen extends HookConsumerWidget {
               return DailyThemeListTile(
                 isCurrent: isCurrent(year.value, month.value, dailyTheme.day),
                 day: dailyTheme.day,
+                weekDay: toWeekday(year.value, month.value, dailyTheme.day),
                 title: dailyTheme.title,
                 worksCount: dailyTheme.worksCount,
                 imageURL: firstWork?.thumbnailImage?.downloadURL,

--- a/lib/utils/to_weekday.dart
+++ b/lib/utils/to_weekday.dart
@@ -1,0 +1,16 @@
+import 'package:aipictors/repositories/config_repository.dart';
+
+String toWeekday(int year, int month, int day) {
+  final language = const ConfigRepository().language;
+  List<String> weekdays = ['月', '火', '水', '木', '金', '土', '日'];
+  if (language == 'en') {
+    weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  }
+  final dateTime = DateTime(
+    year,
+    month,
+    day,
+  );
+  final weekdayIndex = dateTime.weekday;
+  return weekdays[weekdayIndex - 1];
+}

--- a/lib/widgets/list_tile/daily_theme_list_tile.dart
+++ b/lib/widgets/list_tile/daily_theme_list_tile.dart
@@ -7,6 +7,7 @@ class DailyThemeListTile extends HookConsumerWidget {
     Key? key,
     required this.isCurrent,
     required this.day,
+    required this.weekDay,
     required this.title,
     required this.worksCount,
     required this.imageURL,
@@ -16,6 +17,8 @@ class DailyThemeListTile extends HookConsumerWidget {
   final bool isCurrent;
 
   final int day;
+
+  final String weekDay;
 
   final String title;
 
@@ -45,12 +48,29 @@ class DailyThemeListTile extends HookConsumerWidget {
         '${worksCount.toString()}件',
         style: Theme.of(context).textTheme.labelSmall,
       ),
-      leading: Text(
-        isCurrent ? '今日' : '${day.toString()}日',
-        style: TextStyle(
-          fontWeight: FontWeight.bold,
-          color: Theme.of(context).colorScheme.primary,
-        ),
+      leading: Column(
+        children: [
+          const Spacer(),
+          Text(
+            isCurrent ? '今日' : '${day.toString()}日',
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          SizedBox(
+            width: 40,
+            child: Text(
+              '($weekDay)',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          const Spacer()
+        ],
       ),
       subtitle: Text(
         title,


### PR DESCRIPTION
#21 の2番、お題一覧画面での曜日表示を実装しました。
![simulator_screenshot_663C2480-B8FE-4D0C-9978-0E5DC71A3903](https://github.com/aipictors/aipictors-flutter/assets/104188098/a536201c-2114-4a5f-87c1-71771e91d39b)
