### PR TITLE
動作が実装されていないボタンが押された際、メッセージを表示する

### DIFF
--- a/lib/screens/explorer/explorer_screen.dart
+++ b/lib/screens/explorer/explorer_screen.dart
@@ -4,6 +4,7 @@ import 'package:aipictors/screens/explorer/explorer_hot_tags_view.dart';
 import 'package:aipictors/screens/explorer/explorer_latest_albums_view.dart';
 import 'package:aipictors/screens/explorer/explorer_popular_works_view.dart';
 import 'package:aipictors/screens/explorer/explorer_search_view.dart';
+import 'package:aipictors/utils/show_unavailable_snack_bar.dart';
 import 'package:aipictors/widgets/app_bar/search_app_bar.dart';
 import 'package:aipictors/widgets/controller/explorer_tab_controller.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -55,6 +56,7 @@ class ExplorerScreen extends HookConsumerWidget {
                 onPressed: () {
                   isFilled.value = false;
                   search.value = '';
+                  showUnavailableSnackBar(context);
                 },
               ),
           ],

--- a/lib/utils/show_unavailable_snack_bar.dart
+++ b/lib/utils/show_unavailable_snack_bar.dart
@@ -1,0 +1,10 @@
+import 'package:aipictors/default.i18n.dart';
+import 'package:flutter/material.dart';
+
+void showUnavailableSnackBar(BuildContext context) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text('この機能は使用できないみたい。'.i18n),
+    ),
+  );
+}

--- a/lib/widgets/app_bar/work_bottom_app_bar.dart
+++ b/lib/widgets/app_bar/work_bottom_app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:aipictors/mutations/create_work_like.dart';
+import 'package:aipictors/utils/show_unavailable_snack_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -67,7 +68,9 @@ class WorkBottomAppContainer extends HookConsumerWidget {
                 fontWeight: FontWeight.bold,
               ),
             ),
-            onPressed: () {},
+            onPressed: () {
+              showUnavailableSnackBar(context);
+            },
           ),
         ],
       ),


### PR DESCRIPTION
#25 と #28 の暫定対応として、これらのボタンが押された際に、SnackBarを表示するように変更しました。
![unavailable_snackbar](https://github.com/aipictors/aipictors-flutter/assets/104188098/453ed0a3-12c8-4d96-96a7-428ad4b843bd)
