### PR TITLE
シリーズとフォルダのタイトルを2行まで表示可能にする

### DIFF
--- a/lib/screens/album/album_screen.dart
+++ b/lib/screens/album/album_screen.dart
@@ -39,6 +39,7 @@ class AlbumScreen extends HookConsumerWidget {
           appBar: AppBar(
             title: Text(
               album.title,
+              maxLines: 2,
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
           ),

--- a/lib/screens/folder/folder_screen.dart
+++ b/lib/screens/folder/folder_screen.dart
@@ -39,6 +39,7 @@ class FolderScreen extends HookConsumerWidget {
           appBar: AppBar(
             title: Text(
               folder.title,
+              maxLines: 2,
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
           ),


### PR DESCRIPTION
resolve #60 
2行までなら崩れることなく表示できそうなので、2行まで表示可能にしました。
それでも入りきらない場合は画像のように点線になります。
![longfoldertitle](https://github.com/aipictors/aipictors-flutter/assets/104188098/7c6a32ea-d85f-415a-a3ea-a6abd1f46e35)
