### PR TITLE
未いいね・未コレクションのときに、アウトラインアイコンを表示する

### DIFF
--- a/lib/widgets/app_bar/work_bottom_app_bar.dart
+++ b/lib/widgets/app_bar/work_bottom_app_bar.dart
@@ -34,12 +34,16 @@ class WorkBottomAppContainer extends HookConsumerWidget {
               LikeButton(
                 isLiked: isLikedInMemory.value,
                 likeBuilder: (isLiked) {
-                  return Icon(
-                    Icons.favorite_rounded,
+                  if (isLikedInMemory.value) {
+                    return Icon(
+                      Icons.favorite_rounded,
+                      size: 28,
+                      color: Theme.of(context).colorScheme.error,
+                    );
+                  }
+                  return const Icon(
+                    Icons.favorite_outline_rounded,
                     size: 28,
-                    color: isLikedInMemory.value
-                        ? Theme.of(context).colorScheme.error
-                        : null,
                   );
                 },
                 onTap: (isLiked) async {
@@ -52,12 +56,14 @@ class WorkBottomAppContainer extends HookConsumerWidget {
               LikeButton(
                 isLiked: isFoldedInMemory.value,
                 likeBuilder: (bool isFolded) {
-                  return Icon(
-                    Icons.folder,
+                  if (isFoldedInMemory.value) {
+                    return Icon(Icons.folder_rounded,
+                        size: 28, color: Theme.of(context).colorScheme.primary);
+                  }
+
+                  return const Icon(
+                    Icons.folder_outlined,
                     size: 28,
-                    color: isFoldedInMemory.value
-                        ? Theme.of(context).colorScheme.primary
-                        : null,
                   );
                 },
                 onTap: (isFolded) async {

--- a/lib/widgets/button/feed_folder_button.dart
+++ b/lib/widgets/button/feed_folder_button.dart
@@ -24,12 +24,13 @@ class FeedFolderButton extends HookConsumerWidget {
       isLiked: isActiveInMemory.value,
       likeCountPadding: const EdgeInsets.only(left: 4),
       likeBuilder: (isLiked) {
-        return Icon(
-          Icons.folder_rounded,
+        if (isActiveInMemory.value) {
+          return Icon(Icons.folder_rounded,
+              size: 28, color: Theme.of(context).colorScheme.primary);
+        }
+        return const Icon(
+          Icons.folder_outlined,
           size: 28,
-          color: isActiveInMemory.value
-              ? Theme.of(context).colorScheme.primary
-              : null,
         );
       },
       onTap: (isLiked) async {

--- a/lib/widgets/button/feed_like_button.dart
+++ b/lib/widgets/button/feed_like_button.dart
@@ -26,12 +26,13 @@ class FeedLikeButton extends HookConsumerWidget {
       likeCount: count + (isActiveInMemory.value ? 1 : 0),
       likeCountPadding: const EdgeInsets.only(left: 4),
       likeBuilder: (isLiked) {
-        return Icon(
-          Icons.favorite_rounded,
+        if (isActiveInMemory.value) {
+          return Icon(Icons.favorite_rounded,
+              size: 28, color: Theme.of(context).colorScheme.error);
+        }
+        return const Icon(
+          Icons.favorite_outline_rounded,
           size: 28,
-          color: isActiveInMemory.value
-              ? Theme.of(context).colorScheme.error
-              : null,
         );
       },
       onTap: (isLiked) async {


### PR DESCRIPTION
#51 で haruharu-1105さんに提案していただいた、いいねを押す前とあとでボタンを分ける動作を実装しました。